### PR TITLE
Fixed major dynamaxing bug

### DIFF
--- a/src/main/java/com/provismet/cobblemon/gimmick/mixin/ShowdownInterpreterMixin.java
+++ b/src/main/java/com/provismet/cobblemon/gimmick/mixin/ShowdownInterpreterMixin.java
@@ -24,7 +24,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.Iterator;
 import java.util.Map;
 
-@Mixin(ShowdownInterpreter.class)
+@Mixin(value = ShowdownInterpreter.class, remap = false)
 public abstract class ShowdownInterpreterMixin {
     @Shadow @Final
     private static Map<String, Function4<PokemonBattle, InstructionSet, BattleMessage, Iterator<BattleMessage>, InterpreterInstruction>> updateInstructionParser;

--- a/src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/EndInstructionAccessor.java
+++ b/src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/EndInstructionAccessor.java
@@ -1,0 +1,12 @@
+package com.provismet.cobblemon.gimmick.mixin.instructions;
+
+import com.cobblemon.mod.common.api.battles.interpreter.BattleMessage;
+import com.cobblemon.mod.common.battles.interpreter.instructions.EndInstruction;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(value = EndInstruction.class, remap = false)
+public interface EndInstructionAccessor {
+    @Accessor("message")
+    BattleMessage getMessage();
+}

--- a/src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/EndInstructionMixin.java
+++ b/src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/EndInstructionMixin.java
@@ -1,4 +1,4 @@
-package com.provismet.cobblemon.gimmick.mixin;
+package com.provismet.cobblemon.gimmick.mixin.instructions;
 
 
 import com.cobblemon.mod.common.api.battles.interpreter.BattleMessage;
@@ -24,14 +24,19 @@ import java.util.List;
 public class EndInstructionMixin {
     @Shadow @Final private BattleMessage message;
 
+<<<<<<< HEAD:src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/EndInstructionMixin.java
+    @Inject(method = "invoke", at = @At("HEAD"), remap = false)
+    private void injectBeforeInvoke(PokemonBattle battle, CallbackInfo info) {
+        BattleMessage message = ((EndInstructionAccessor) this).getMessage();
+        String raw = message.getRawMessage();
+=======
     @Inject(method = "invoke", at = @At("TAIL"), remap = false)
     private void injectBeforeInvoke (PokemonBattle battle, CallbackInfo info) {
         List<String> logs = battle.getShowdownMessages();
         if (logs.isEmpty()) return; // Nothing to check
+>>>>>>> e207f9ae242cd387574d2f3a68c7aca1511d0a23:src/main/java/com/provismet/cobblemon/gimmick/mixin/EndInstructionMixin.java
 
-        String battleLog = logs.getLast(); // Get the last message
-
-        String[] parts = battleLog.split("\\|");
+        String[] parts = raw.split("\\|");
         boolean containsDynamax = Arrays.stream(parts).anyMatch(part -> part.contains("Dynamax"));
 
         if (containsDynamax) {

--- a/src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/EndInstructionMixin.java
+++ b/src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/EndInstructionMixin.java
@@ -24,17 +24,10 @@ import java.util.List;
 public class EndInstructionMixin {
     @Shadow @Final private BattleMessage message;
 
-<<<<<<< HEAD:src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/EndInstructionMixin.java
     @Inject(method = "invoke", at = @At("HEAD"), remap = false)
-    private void injectBeforeInvoke(PokemonBattle battle, CallbackInfo info) {
+    private void injectBeforeInvoke(PokemonBattle battle, CallbackInfo ci) {
         BattleMessage message = ((EndInstructionAccessor) this).getMessage();
         String raw = message.getRawMessage();
-=======
-    @Inject(method = "invoke", at = @At("TAIL"), remap = false)
-    private void injectBeforeInvoke (PokemonBattle battle, CallbackInfo info) {
-        List<String> logs = battle.getShowdownMessages();
-        if (logs.isEmpty()) return; // Nothing to check
->>>>>>> e207f9ae242cd387574d2f3a68c7aca1511d0a23:src/main/java/com/provismet/cobblemon/gimmick/mixin/EndInstructionMixin.java
 
         String[] parts = raw.split("\\|");
         boolean containsDynamax = Arrays.stream(parts).anyMatch(part -> part.contains("Dynamax"));

--- a/src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/StartInstructionAccessor.java
+++ b/src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/StartInstructionAccessor.java
@@ -1,0 +1,12 @@
+package com.provismet.cobblemon.gimmick.mixin.instructions;
+
+import com.cobblemon.mod.common.api.battles.interpreter.BattleMessage;
+import com.cobblemon.mod.common.battles.interpreter.instructions.StartInstruction;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(value = StartInstruction.class, remap = false)
+public interface StartInstructionAccessor {
+    @Accessor("message")
+    BattleMessage getMessage();
+}

--- a/src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/StartInstructionMixin.java
+++ b/src/main/java/com/provismet/cobblemon/gimmick/mixin/instructions/StartInstructionMixin.java
@@ -1,4 +1,4 @@
-package com.provismet.cobblemon.gimmick.mixin;
+package com.provismet.cobblemon.gimmick.mixin.instructions;
 
 import com.cobblemon.mod.common.api.battles.interpreter.BattleMessage;
 import com.cobblemon.mod.common.api.battles.model.PokemonBattle;
@@ -24,12 +24,10 @@ public class StartInstructionMixin  {
 
     @Inject(method = "invoke", at = @At("HEAD"), remap = false)
     private void injectBeforeInvoke(PokemonBattle battle, CallbackInfo info) {
-        List<String> logs = battle.getShowdownMessages();
-        if (logs.isEmpty()) return; // Nothing to check
+        BattleMessage message = ((StartInstructionAccessor) this).getMessage();
+        String raw = message.getRawMessage();
 
-        String battleLog = logs.getLast(); // Get the last message
-
-        String[] parts = battleLog.split("\\|");
+        String[] parts = raw.split("\\|");
         boolean containsDynamax = Arrays.stream(parts).anyMatch(part -> part.contains("Dynamax"));
         boolean containsGmax = Arrays.stream(parts).anyMatch(part -> part.contains("Gmax"));
 

--- a/src/main/resources/gimme-that-gimmick.mixins.json
+++ b/src/main/resources/gimme-that-gimmick.mixins.json
@@ -11,7 +11,11 @@
         "ShowdownActionRequestMixin",
         "ShowdownInterpreterMixin",
         "ShowdownSpeciesMixin",
-        "StartInstructionMixin"
+        "StartInstructionMixin",
+        "instructions.EndInstructionAccessor",
+        "instructions.EndInstructionMixin",
+        "instructions.StartInstructionAccessor",
+        "instructions.StartInstructionMixin"
     ],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
You would dynamax all the Pokémon's when you do things a certain way since it was calling the logic even if it was a -start instruction and checking the entire log instead of it being the present one