### PR TITLE
Remove invalid EndInstructionMixin and StartInstructionMixin entries

### DIFF
--- a/src/main/resources/gimme-that-gimmick.mixins.json
+++ b/src/main/resources/gimme-that-gimmick.mixins.json
@@ -4,14 +4,12 @@
     "compatibilityLevel": "JAVA_21",
     "server": [
         "CobblemonNetworkMixin",
-        "EndInstructionMixin",
         "GraalShowdownUnbundlerMixin",
         "MoveActionResponseMixin",
         "PokemonBattleMixin",
         "ShowdownActionRequestMixin",
         "ShowdownInterpreterMixin",
         "ShowdownSpeciesMixin",
-        "StartInstructionMixin",
         "instructions.EndInstructionMixin",
         "instructions.StartInstructionMixin"
     ],


### PR DESCRIPTION
The mixin list in `gimme-that-gimmick.mixins.json` was still referencing `EndInstructionMixin` and `StartInstructionMixin`, without the `instructions.` package, which led to build failures and server crashes (per the jar from Modrinth).

This change removes those two old entries (that were presumably meant to be removed anyway). They remain included under the `instructions.` package, so no functionality is affected.