### PR TITLE
Glow fix and showdown caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ modid=gimme-that-gimmick
 # Dependencies
 fabric_version=0.116.7+1.21.1
 polymer_version=0.9.18+1.21.1
-cobblemon_version=1.7.2+1.21.1
+cobblemon_version=1.7.3+1.21.1
 lilylib_version=1.4.1-mc1.21
 
 # Publishing

--- a/src/main/java/com/provismet/cobblemon/gimmick/config/Options.java
+++ b/src/main/java/com/provismet/cobblemon/gimmick/config/Options.java
@@ -15,7 +15,7 @@ import java.nio.file.Path;
 public abstract class Options {
     private static final Path FILE = FabricLoader.getInstance().getConfigDir().resolve("gimme-that-gimmick.json");
 
-    private static boolean overrideShowdown = true;
+    private static boolean autoUpdateShowdown = true;
     private static boolean megaEvolution = true;
     private static boolean zMoves = true;
     private static boolean dynamax = true;
@@ -35,8 +35,8 @@ public abstract class Options {
         load();
     }
 
-    public static boolean shouldOverrideShowdown () {
-        return overrideShowdown;
+    public static boolean shouldAutoUpdateShowdown () {
+        return autoUpdateShowdown;
     }
 
     public static boolean enabledMegaEvolution () {
@@ -97,7 +97,7 @@ public abstract class Options {
 
     public static void save () {
         JsonObject json = new JsonBuilder()
-            .append("override_showdown", overrideShowdown)
+            .append("auto_update_showdown", autoUpdateShowdown)
             .append("enable_mega_evolution", megaEvolution)
             .append("enable_z-moves", zMoves)
             .append("enable_dynamax", dynamax)
@@ -126,7 +126,7 @@ public abstract class Options {
         try {
             JsonReader reader = JsonReader.file(FILE.toFile());
             if (reader != null) {
-                reader.getBoolean("override_showdown").ifPresent(val -> overrideShowdown = val);
+                reader.getBoolean("override_showdown").ifPresent(val -> autoUpdateShowdown = val);
                 reader.getBoolean("enable_mega_evolution").ifPresent(val -> megaEvolution = val);
                 reader.getBoolean("enable_z-moves").ifPresent(val -> zMoves = val);
                 reader.getBoolean("enable_dynamax").ifPresent(val -> dynamax = val);

--- a/src/main/java/com/provismet/cobblemon/gimmick/mixin/GraalShowdownUnbundlerMixin.java
+++ b/src/main/java/com/provismet/cobblemon/gimmick/mixin/GraalShowdownUnbundlerMixin.java
@@ -1,76 +1,19 @@
 package com.provismet.cobblemon.gimmick.mixin;
 
 import com.cobblemon.mod.common.battles.runner.graal.GraalShowdownUnbundler;
-import com.provismet.cobblemon.gimmick.GimmeThatGimmickMain;
-import com.provismet.cobblemon.gimmick.config.Options;
+import com.provismet.cobblemon.gimmick.util.ShowdownPatcher;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 
 /**
  * Code adapted from to YajatKaul @ MegaShowdown.
  */
 @Mixin(GraalShowdownUnbundler.class)
 public abstract class GraalShowdownUnbundlerMixin {
-    @Unique private boolean loaded = false;
-
     @Inject(method = "attemptUnbundle", at = @At("TAIL"), remap = false)
     private void replaceScripts (CallbackInfo info) {
-        if(!loaded){
-            loaded = true;
-            if (Options.shouldOverrideShowdown()) {
-                Path showdown_sim = Path.of("./showdown/sim");
-                Path showdown_data = Path.of("./showdown/data");
-                Path showdown_dir = Path.of("./showdown");
-                Path showdown_mod_data = Path.of("./showdown/data/mods/cobblemon");
-
-                try {
-                    Files.createDirectories(showdown_sim);
-                    Files.createDirectories(showdown_data);
-
-                    if (!Files.exists(showdown_mod_data.resolve("items.js"))) {
-                        yoink("/showdown_scripts/mods/items.js", showdown_mod_data.resolve("items.js"));
-                    }
-                    if (!Files.exists(showdown_mod_data.resolve("conditions.js"))) {
-                        yoink("/showdown_scripts/mods/conditions.js", showdown_mod_data.resolve("conditions.js"));
-                    }
-                    if (!Files.exists(showdown_mod_data.resolve("typechart.js"))) {
-                        yoink("/showdown_scripts/mods/typechart.js", showdown_mod_data.resolve("typechart.js"));
-                    }
-
-                    yoink("/showdown_scripts/battle-actions.js", showdown_sim.resolve("battle-actions.js"));
-                    yoink("/showdown_scripts/pokemon.js", showdown_sim.resolve("pokemon.js"));
-                    yoink("/showdown_scripts/conditions.js", showdown_data.resolve("conditions.js"));
-                    yoink("/showdown_scripts/index.js", showdown_dir.resolve("index.js"));
-                    yoink("/showdown_scripts/side.js", showdown_sim.resolve("side.js"));
-
-                    GimmeThatGimmickMain.LOGGER.info("All files are ready!");
-                } catch (IOException e) {
-                    GimmeThatGimmickMain.LOGGER.error("Failed to prepare required files: {}", e.getMessage());
-                }
-            }
-        }
-    }
-
-    @Unique
-    private void yoink (String resourcePath, Path targetPath) {
-        try (InputStream inputStream = this.getClass().getResourceAsStream(resourcePath)) {
-            if (inputStream == null) {
-                GimmeThatGimmickMain.LOGGER.error("Fallback file not found: {}", resourcePath);
-                return;
-            }
-            Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
-            GimmeThatGimmickMain.LOGGER.info("Loaded Showdown override file: {}", targetPath);
-        } catch (IOException e) {
-            GimmeThatGimmickMain.LOGGER.error("Failed to copy Showdown override file {}: {}", resourcePath, e.getMessage());
-        }
+        ShowdownPatcher.patch();
     }
 }

--- a/src/main/java/com/provismet/cobblemon/gimmick/mixin/TamableEntityMixin.java
+++ b/src/main/java/com/provismet/cobblemon/gimmick/mixin/TamableEntityMixin.java
@@ -1,0 +1,30 @@
+package com.provismet.cobblemon.gimmick.mixin;
+
+import com.cobblemon.mod.common.entity.pokemon.PokemonEntity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.passive.TameableEntity;
+import net.minecraft.scoreboard.Team;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+// This fixes the glow color issue
+@Mixin(TameableEntity.class)
+public abstract class TamableEntityMixin extends AnimalEntity {
+    protected TamableEntityMixin(EntityType<? extends AnimalEntity> entityType, World level) {
+        super(entityType, level);
+    }
+
+    @Inject(method = "getScoreboardTeam", at = @At("HEAD"), cancellable = true)
+    private void getTeamInject(CallbackInfoReturnable<Team> cir) {
+        TameableEntity tamableAnimal = (TameableEntity) (Object) this;
+
+        if (tamableAnimal instanceof PokemonEntity) {
+            cir.setReturnValue(super.getScoreboardTeam());
+            cir.cancel();
+        }
+    }
+}

--- a/src/main/java/com/provismet/cobblemon/gimmick/util/ShowdownPatcher.java
+++ b/src/main/java/com/provismet/cobblemon/gimmick/util/ShowdownPatcher.java
@@ -1,0 +1,86 @@
+package com.provismet.cobblemon.gimmick.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.provismet.cobblemon.gimmick.GimmeThatGimmickMain;
+import com.provismet.cobblemon.gimmick.config.Options;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+public class ShowdownPatcher {
+    private static final String SHOWDOWN_VERSION = "1.0.0";
+    private static final Gson GSON = new Gson();
+
+    public static void patch() {
+        if (Options.shouldAutoUpdateShowdown()) {
+            Path showdown_sim = Path.of("./showdown/sim");
+            Path showdown_data = Path.of("./showdown/data");
+            Path showdown_dir = Path.of("./showdown");
+            Path showdown_mod_data = Path.of("./showdown/data/mods/cobblemon");
+            Path versionFile = showdown_dir.resolve("GTGPatch.json");
+
+            try {
+                Files.createDirectories(showdown_sim);
+                Files.createDirectories(showdown_data);
+
+                if (isUpToDate(versionFile)) {
+                    GimmeThatGimmickMain.LOGGER.info("Showdown files are up to date (v{}).", SHOWDOWN_VERSION);
+                    return;
+                }
+
+                if (!Files.exists(showdown_mod_data.resolve("items.js"))) {
+                    yoink("/showdown_scripts/mods/items.js", showdown_mod_data.resolve("items.js"));
+                }
+                if (!Files.exists(showdown_mod_data.resolve("conditions.js"))) {
+                    yoink("/showdown_scripts/mods/conditions.js", showdown_mod_data.resolve("conditions.js"));
+                }
+                if (!Files.exists(showdown_mod_data.resolve("typechart.js"))) {
+                    yoink("/showdown_scripts/mods/typechart.js", showdown_mod_data.resolve("typechart.js"));
+                }
+
+                yoink("/showdown_scripts/battle-actions.js", showdown_sim.resolve("battle-actions.js"));
+                yoink("/showdown_scripts/pokemon.js", showdown_sim.resolve("pokemon.js"));
+                yoink("/showdown_scripts/conditions.js", showdown_data.resolve("conditions.js"));
+                yoink("/showdown_scripts/index.js", showdown_dir.resolve("index.js"));
+                yoink("/showdown_scripts/side.js", showdown_sim.resolve("side.js"));
+
+                writeVersionFile(versionFile);
+                GimmeThatGimmickMain.LOGGER.info("All files are ready!");
+            } catch (IOException e) {
+                GimmeThatGimmickMain.LOGGER.error("Failed to prepare required files: {}", e.getMessage());
+            }
+        }
+    }
+
+    private static boolean isUpToDate(Path versionFile) {
+        if (!Files.exists(versionFile)) return false;
+        try (Reader reader = Files.newBufferedReader(versionFile)) {
+            JsonObject json = GSON.fromJson(reader, JsonObject.class);
+            return json != null && SHOWDOWN_VERSION.equals(json.get("version").getAsString());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static void writeVersionFile(Path versionFile) throws IOException {
+        JsonObject json = new JsonObject();
+        json.addProperty("version", SHOWDOWN_VERSION);
+        Files.writeString(versionFile, GSON.toJson(json));
+    }
+
+    private static void yoink(String resourcePath, Path targetPath) {
+        try (InputStream inputStream = ShowdownPatcher.class.getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                GimmeThatGimmickMain.LOGGER.error("Fallback file not found: {}", resourcePath);
+                return;
+            }
+            Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+            GimmeThatGimmickMain.LOGGER.info("Loaded fallback file: {}", targetPath);
+        } catch (IOException e) {
+            GimmeThatGimmickMain.LOGGER.error("Failed to copy fallback file {}: {}", resourcePath, e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/gimme-that-gimmick.mixins.json
+++ b/src/main/resources/gimme-that-gimmick.mixins.json
@@ -11,6 +11,7 @@
     "ShowdownActionRequestMixin",
     "ShowdownInterpreterMixin",
     "ShowdownSpeciesMixin",
+    "TamableEntityMixin",
     "instructions.EndInstructionMixin",
     "instructions.StartInstructionMixin"
   ],


### PR DESCRIPTION
Now showdown files dont overwrite everytime you open the game only when u update the version id in ShowdownPatcher and Fixed the glow color of all the pokemons